### PR TITLE
v0.1.7: Better RAT cookie checks and cleanup

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -1,9 +1,9 @@
 package bot
 
 import (
+	"errors"
 	"fmt"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/wneessen/arrgo/config"
 	"github.com/wneessen/arrgo/crypto"

--- a/bot/handler_guilddelete.go
+++ b/bot/handler_guilddelete.go
@@ -1,8 +1,8 @@
 package bot
 
 import (
+	"errors"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	"github.com/wneessen/arrgo/model"
 )
 

--- a/bot/handler_presenceupdate_playsot.go
+++ b/bot/handler_presenceupdate_playsot.go
@@ -1,9 +1,9 @@
 package bot
 
 import (
+	"errors"
 	"fmt"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	"github.com/wneessen/arrgo/model"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"

--- a/bot/httpclient.go
+++ b/bot/httpclient.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"github.com/wneessen/arrgo/crypto"
 	"io"
@@ -44,6 +45,13 @@ type APITimeRFC3339 time.Time
 
 // SOTReferer is the referer that apparently is needed for the SoT API to accept requests
 const SOTReferer = "https://www.seaofthieves.com/profile/achievements"
+
+// HTTP client related errors
+var (
+	// ErrSOTUnauth should be used when requrests to the SoT API were not successful due to expired
+	// tokens
+	ErrSOTUnauth = errors.New("failed to fetch Sea of Thieves content, due to being unauthorized")
+)
 
 // NewHTTPClient returns a HTTPClient object
 func NewHTTPClient() (*HTTPClient, error) {

--- a/bot/sc_handler_rarethief_traderoutes.go
+++ b/bot/sc_handler_rarethief_traderoutes.go
@@ -2,9 +2,9 @@ package bot
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	"github.com/wneessen/arrgo/model"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"

--- a/bot/sc_handler_register.go
+++ b/bot/sc_handler_register.go
@@ -1,9 +1,9 @@
 package bot
 
 import (
+	"errors"
 	"fmt"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	"github.com/wneessen/arrgo/config"
 	"github.com/wneessen/arrgo/crypto"
 	"github.com/wneessen/arrgo/model"

--- a/bot/sc_handler_sot_dailydeeds.go
+++ b/bot/sc_handler_sot_dailydeeds.go
@@ -2,9 +2,9 @@ package bot
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	"github.com/wneessen/arrgo/model"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"

--- a/bot/sc_handler_sot_flameheart.go
+++ b/bot/sc_handler_sot_flameheart.go
@@ -1,9 +1,9 @@
 package bot
 
 import (
+	"errors"
 	"fmt"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	"github.com/wneessen/arrgo/crypto"
 	"github.com/wneessen/arrgo/model"
 	"strings"

--- a/bot/sc_handler_sot_setrat.go
+++ b/bot/sc_handler_sot_setrat.go
@@ -3,9 +3,9 @@ package bot
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/bwmarrin/discordgo"
-	"github.com/pkg/errors"
 	"github.com/wneessen/arrgo/model"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/kkyr/fig v0.3.0
 	github.com/lib/pq v1.10.0
-	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.27.0
 	golang.org/x/text v0.3.7
 )


### PR DESCRIPTION
- The RAT cookie validator now does a HTTP request as well to make sure there is no HTTP 401 returned
- The user stats slash command was failing if the RAT cookie was expired
- We were using github.com/pkg/errors instead of the Go errors module