### PR TITLE
v0.2.2: Fix `/compare` command in DMs

### DIFF
--- a/bot/sc_handler_compare.go
+++ b/bot/sc_handler_compare.go
@@ -25,18 +25,18 @@ func (b *Bot) SlashCmdSoTCompare(s *discordgo.Session, i *discordgo.InteractionC
 	}
 	ots := time.Now().Add(d)
 
-	u, err := b.Model.User.GetByUserID(i.Member.User.ID)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve user from DB: %w", err)
-	}
-	if err := b.StoreSoTUserStats(u); err != nil {
-		return fmt.Errorf("failed to update user stats in DB: %w", err)
-	}
-	cus, err := b.Model.UserStats.GetByUserID(u.ID)
+	r, err := b.NewRequester(i.Interaction)
 	if err != nil {
 		return err
 	}
-	ous, err := b.Model.UserStats.GetByUserIDAtTime(u.ID, ots)
+	if err := b.StoreSoTUserStats(r.User); err != nil {
+		return fmt.Errorf("failed to update user stats in DB: %w", err)
+	}
+	cus, err := b.Model.UserStats.GetByUserID(r.User.ID)
+	if err != nil {
+		return err
+	}
+	ous, err := b.Model.UserStats.GetByUserIDAtTime(r.User.ID, ots)
 	if err != nil {
 		return err
 	}

--- a/bot/version.go
+++ b/bot/version.go
@@ -1,3 +1,3 @@
 package bot
 
-const Version = "0.2.1"
+const Version = "0.2.2"


### PR DESCRIPTION
Fixes #25
In `/compare` we were assuming an interaction in which the user is read from a channel, which would fail in a DM. Since we already have the `*Requester` model which can differentiate and provide reliable information, by using that instead in the `/compare` command fixes the possible NPD