### PR TITLE
v0.2.3: Fix `/compare` command

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -229,21 +229,20 @@ func (b *Bot) StartTimeUnix() int64 {
 
 // NewRequester returns a Requester based on if it's a channel interaction or DM
 func (b *Bot) NewRequester(i *discordgo.Interaction) (*Requester, error) {
-	r := &Requester{nil, b.Model.User, nil}
 	if i.User != nil {
 		u, err := b.Model.User.GetByUserID(i.User.ID)
 		if err != nil {
 			switch {
 			case errors.Is(err, model.ErrUserNotExistent):
-				return r, fmt.Errorf("user is not registered")
+				return nil, fmt.Errorf("user is not registered")
 			default:
-				return r, err
+				return nil, err
 			}
 		}
-		r.User = u
+		return NewRequesterFromUser(u, b.Model.User)
 	}
 	if i.Member != nil {
-		r.Member = i.Member
+		return NewRequesterFromMember(i.Member, b.Model.User)
 	}
-	return r, nil
+	return nil, fmt.Errorf("neither interaction user nor member found")
 }

--- a/bot/sc_handler_sot_userstats.go
+++ b/bot/sc_handler_sot_userstats.go
@@ -240,7 +240,11 @@ func (b *Bot) ScheduledEventUpdateUserStats() error {
 
 // StoreSoTUserStats will retrieve the latest user stats from the API and store them in the DB
 func (b *Bot) StoreSoTUserStats(u *model.User) error {
-	r := &Requester{nil, b.Model.User, u}
+	r, err := NewRequesterFromUser(u, b.Model.User)
+	if err != nil {
+		b.Log.Warn().Msgf("failed to create new requester: %s", err)
+		return err
+	}
 	ub, err := b.SoTGetUserBalance(r)
 	if err != nil {
 		switch {

--- a/model/model.go
+++ b/model/model.go
@@ -41,6 +41,9 @@ var (
 
 	// ErrDeedDuplicate should be used in case a deed to be inserted into the database already exists
 	ErrDeedDuplicate = errors.New("deed already existent in database")
+
+	// ErrUserNil should be returned if the check for the *User returns nil
+	ErrUserNil = errors.New("user pointer must not be nil:w")
 )
 
 // Model is a collection of all available models

--- a/model/user_pref.go
+++ b/model/user_pref.go
@@ -205,6 +205,10 @@ func getUserPrefEnc[V string | bool | int | int64](m UserModel, u *User, k UserP
 	var bv []byte
 	var ob bytes.Buffer
 
+	if u == nil {
+		return v, ErrUserNil
+	}
+
 	q := `SELECT pref_val
             FROM user_prefs u
            WHERE u.user_id = $1 AND u.pref_key = $2 AND u.is_enc = true`


### PR DESCRIPTION
With the last patch we introduced and issue with the `/compare` command that caused nil pointer dereferences. The `Requester` handling is now more stable